### PR TITLE
feat: add zone to tribun news api

### DIFF
--- a/api/controllers/newshandler/TribunNews.ts
+++ b/api/controllers/newshandler/TribunNews.ts
@@ -53,6 +53,11 @@ class TribunNews {
             }
             return res.status(200).send(dataResponse)
         } catch(e) {
+            if(e.message.includes('404')){
+                return res.status(404).send({
+                    message: "Type not found for this zone"
+                })
+            }
             return res.status(500).send({
                 message: `${e.message}`
             })

--- a/api/routes.ts
+++ b/api/routes.ts
@@ -53,8 +53,13 @@ router.get('/', (_, res: Response) => {
             },
             "Tribun News": {
                 all: "https://berita-indo-api.vercel.app/v1/tribun-news",
+                zone: ["jakarta", "jabar", "mataram", "mataraman", "medan", "padang", "flores", "sulbar", "ambon",
+                    "wartakota", "bogor", "pantura", "madura", "palembang", "pekanbaru", "banjarmasin", "pontianak", "papua", "bekasi",
+                    "cirebon", "jogja", "bali", "bangka", "jambi", "kaltim", "palu", "papuabarat", "banten", "jateng", "jatim", "aceh",
+                    "batam", "sumsel", "kalteng", "makassar", "tangerang", "solo", "surabaya", "prohaba", "belitung", "lampung", "kaltara",
+                    "lombok", "depok", "banyumas", "suryamalang", "sultra", "babel", "kupang", "manado", "ternate"],
                 listType: ["bisnis", "superskor", "sport", "seleb", "lifestyle", "travel", "parapuan", "otomotif", "techno", "ramadan"],
-                example: "https://berita-indo-api.vercel.app/v1/tribun-news/techno",
+                example: "https://berita-indo-api.vercel.app/v1/tribun-news/jakarta/techno",
             },
         },
         author: "Satya Wikananda",
@@ -78,8 +83,8 @@ router.get('/v1/okezone-news/:type', BeritaIndo.OkezoneNews.getNews)
 router.get('/v1/liputan6-news/', BeritaIndo.Liputan6News.getAllNews)
 router.get('/v1/bbc-news/:type', BeritaIndo.BbcNews.getNews)
 router.get('/v1/bbc-news/', BeritaIndo.BbcNews.getAllNews)
-router.get('/v1/tribun-news/:type', BeritaIndo.TribunNews.getNews)
-router.get('/v1/tribun-news/', BeritaIndo.TribunNews.getAllNews)
+router.get('/v1/tribun-news/:zone/:type', BeritaIndo.TribunNews.getNews)
+router.get('/v1/tribun-news/:zone?', BeritaIndo.TribunNews.getAllNews)
 
 router.all('*', BeritaIndo.notFound)
 

--- a/const.ts
+++ b/const.ts
@@ -16,4 +16,4 @@ export const RSS_OKEZONE = {
 }
 export const RSS_LIPUTAN6: string = 'https://feed.liputan6.com/rss'
 export const RSS_BBC: string = 'https://feeds.bbci.co.uk/indonesia/{type}/rss.xml'
-export const RSS_TRIBUN: string = 'https://api.tribunnews.com/rss/'
+export const RSS_TRIBUN: string = 'https://{zone}.tribunnews.com/rss/'

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An api to display news in Indonesia",
   "main": "index.js",
   "scripts": {
+    "dev": "ts-node ./api/server.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/types/common.ts
+++ b/types/common.ts
@@ -14,6 +14,11 @@ export type TypeBbc = "dunia" | "berita_indonesia" | "olahraga" | "majalah" | "m
 
 export type TypeTribun = "bisnis" | "superskor" | "sport" | "seleb" | "lifestyle" | "travel" | "parapuan" | "otomotif" | "techno" | "ramadan"
 
+export type ZoneTribun = "jakarta" | "jabar" | "mataram" | "mataraman" | "medan" | "padang" | "flores" | "sulbar" | "ambon" |
+    "wartakota" | "bogor" | "pantura" | "madura" | "palembang" | "pekanbaru" | "banjarmasin" | "pontianak" | "papua" | "bekasi" |
+    "cirebon" | "jogja" | "bali" | "bangka" | "jambi" | "kaltim" | "palu" | "papuabarat" | "banten" | "jateng" | "jatim" | "aceh" |
+    "batam" | "sumsel" | "kalteng" | "makassar" | "tangerang" | "solo" | "surabaya" | "prohaba" | "belitung" | "lampung" | "kaltara" |
+    "lombok" | "depok" | "banyumas" | "suryamalang" | "sultra" | "babel" | "kupang" | "manado" | "ternate"
 export interface DataResponse {
     code: number
     status?: string
@@ -27,5 +32,5 @@ export interface ListsApi {
     all?: string
     type?: string
     listType?: string[]
-    example?:string
+    example?: string
 }


### PR DESCRIPTION
This PR is to fix #10 and add zone params to api TribunNews
Currently, main rss API tribunnews is not support with params type, but it's work with subdomain api

`api.tribunnews/:type` => 404

`:zone.tribunnews/:type` => 200

In this PR, we add additional route for tribunnews, so we can access them with:
- `BASEURL/v1/tribun-news` (get list news on main api)
- `BASEURL/v1/tribun-news/:zone` (get list news on zone api)
- `BASEURL/v1/tribun-news/:zone/:type` (get list news on zone api with type)

NOTE: some zone doesnt have some type, may be we can discuss later how to handle it
 

